### PR TITLE
LFLT-443 TLP v1 to v2 query conversion adds empty parameters to the context

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0-dev</version>
+        <version>2.0.1-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverter.java
@@ -67,7 +67,7 @@ public class LogRequestToDSLQueryModelConverter implements Converter<LogRequest,
 
         DSL_OBJECT_PROVIDER_MAP.forEach((dslObject, mapperFunction) -> {
             String value = mapperFunction.apply(logRequest);
-            if (Objects.nonNull(value)) {
+            if (Objects.nonNull(value) && value.length() > 0) {
                 setLogicalChain(dslConditionGroup);
                 dslConditionGroup.getConditions().add(createSimpleCondition(dslObject, value));
             }

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverterTest.java
@@ -84,6 +84,7 @@ class LogRequestToDSLQueryModelConverterTest {
         // given
         LogRequest logRequest = new LogRequest();
         logRequest.setContent("some message to be queried");
+        logRequest.setLevel("");
 
         DSLQueryModel expectedDslQueryModel = new DSLQueryModel();
         expectedDslQueryModel.getConditionGroups().add(new DSLConditionGroup());

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>tlp</artifactId>
-    <version>2.0.0-dev</version>
+    <version>2.0.1-dev</version>
     <modules>
         <module>web</module>
         <module>core</module>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0-dev</version>
+        <version>2.0.1-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Added checking for empty string on LogRequest (TLP v1 API) conversion
 - Aligned unit test
 - Bumped app version to 2.0.1