### PR TITLE
LFLT-569 Add support for querying MDC data in TLP / LFLT-572 Add support for querying log thread in TLP

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.4.0-dev</version>
+        <version>2.5.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverter.java
@@ -7,6 +7,7 @@ import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLConditionGroup;
 import hu.psprog.leaflet.tlql.ir.DSLLogicalOperator;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import hu.psprog.leaflet.tlql.ir.DSLOrderDirection;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
@@ -84,7 +85,7 @@ public class LogRequestToDSLQueryModelConverter implements Converter<LogRequest,
     private DSLCondition createSimpleCondition(DSLObject dslObject, String value) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(dslObject);
+        dslCondition.setObjectContext(new DSLObjectContext(dslObject, null));
         dslCondition.setOperator(dslObject == DSLObject.MESSAGE
                 ? DSLOperator.LIKE
                 : DSLOperator.EQUALS);
@@ -114,7 +115,7 @@ public class LogRequestToDSLQueryModelConverter implements Converter<LogRequest,
             }
 
             dslCondition = new DSLCondition();
-            dslCondition.setObject(DSLObject.TIMESTAMP);
+            dslCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
             dslCondition.setOperator(dslOperator);
             dslCondition.setTimestampValue(dslTimestampValue);
         }

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LoggingEventEntityToDomainConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/conversion/LoggingEventEntityToDomainConverter.java
@@ -31,6 +31,8 @@ public class LoggingEventEntityToDomainConverter implements Converter<hu.psprog.
                 .withException(Optional.ofNullable(source.getException())
                         .map(this::convert)
                         .orElse(null))
+                .withContext(Optional.ofNullable(source.getContext())
+                        .orElseGet(Collections::emptyMap))
                 .build();
     }
 

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/ExpressionStrategyGroup.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/ExpressionStrategyGroup.java
@@ -22,6 +22,11 @@ public enum ExpressionStrategyGroup {
     TEXT_CONDITION(DSLObject.LEVEL, DSLObject.SOURCE, DSLObject.LOGGER, DSLObject.MESSAGE),
 
     /**
+     * Group for log context value processing.
+     */
+    TEXT_MAP_CONDITION(DSLObject.CONTEXT),
+
+    /**
      * Group for timestamp value processing.
      */
     TIMESTAMP_CONDITION(DSLObject.TIMESTAMP);

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LoggingEvent.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LoggingEvent.java
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Domain object for parsing and storing received log events.
@@ -35,6 +36,9 @@ public class LoggingEvent {
     @Indexed(name = "tlp-index.source")
     private String source;
 
+    @Indexed(name = "tlp-index.context")
+    private Map<String, String> context;
+
     public static LoggingEventBuilder getBuilder() {
         return new LoggingEventBuilder();
     }
@@ -50,6 +54,7 @@ public class LoggingEvent {
         private ThrowableProxyLogItem exception;
         private Date timeStamp;
         private String source;
+        private Map<String, String> context;
 
         private LoggingEventBuilder() {
         }
@@ -99,6 +104,11 @@ public class LoggingEvent {
             return this;
         }
 
+        public LoggingEventBuilder withContext(Map<String, String> context) {
+            this.context = context;
+            return this;
+        }
+
         public LoggingEvent build() {
             LoggingEvent loggingEvent = new LoggingEvent();
             loggingEvent.content = this.content;
@@ -108,6 +118,7 @@ public class LoggingEvent {
             loggingEvent.timeStamp = this.timeStamp;
             loggingEvent.level = this.level;
             loggingEvent.source = this.source;
+            loggingEvent.context = this.context;
             return loggingEvent;
         }
     }

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/builder/ExpressionBuilder.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/builder/ExpressionBuilder.java
@@ -57,7 +57,7 @@ public class ExpressionBuilder {
             BooleanBuilder groupExpression = new BooleanBuilder();
 
             for (DSLCondition dslCondition : dslConditionGroup.getConditions()) {
-                ExpressionStrategyGroup group = ExpressionStrategyGroup.getByApplicationDSLObject(dslCondition.getObject());
+                ExpressionStrategyGroup group = ExpressionStrategyGroup.getByApplicationDSLObject(dslCondition.getObjectContext().getObject());
                 BooleanExpression conditionExpression = expressionStrategyMap.get(group).applyStrategy(event, dslCondition);
 
                 chainExpression(groupExpression, previousOperator, conditionExpression);

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringMapQDSLPathMappingRegistry.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringMapQDSLPathMappingRegistry.java
@@ -1,0 +1,84 @@
+package hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.impl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.MapPath;
+import com.querydsl.core.types.dsl.StringPath;
+import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
+import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
+import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLOperator;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * {@link MappingRegistry} implementation for database fields accessible via {@link MapPath} QueryDSL expressions.
+ * Currently used for context field of log records. Base type is string-string map.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class StringMapQDSLPathMappingRegistry implements MappingRegistry<MapPath<String, String, StringPath>, Map<String, String>> {
+
+    private static final Map<DSLOperator, BiFunction<MapPath<String, String, StringPath>, Map<String, String>, BooleanExpression>> SINGLE_VALUE_BOOLEAN_EXPRESSION_GENERATOR_MAP = Map.of(
+            DSLOperator.EQUALS, (mapPath, valueMap) -> singleValueBaseExpression(valueMap, mapContains(mapPath)),
+            DSLOperator.NOT_EQUALS, (mapPath, valueMap) -> singleValueBaseExpression(valueMap, mapContains(mapPath)).not(),
+            DSLOperator.LIKE, (mapPath, valueMap) -> singleValueBaseExpression(valueMap, mapContainsLike(mapPath))
+    );
+
+    private static final Map<DSLOperator, BiFunction<MapPath<String, String, StringPath>, Map<String, String>[], BooleanExpression>> MULTI_VALUE_BOOLEAN_EXPRESSION_GENERATOR_MAP = Map.of(
+            DSLOperator.EITHER, StringMapQDSLPathMappingRegistry::multiValueBaseExpression,
+            DSLOperator.NONE, (mapPath, valueMapArray) -> multiValueBaseExpression(mapPath, valueMapArray).not()
+    );
+
+    @Override
+    public Function<QLoggingEvent, MapPath<String, String, StringPath>> getQDSLPath(DSLObject dslObject) {
+
+        if (dslObject != DSLObject.CONTEXT) {
+            throw new IllegalArgumentException("DSL object must be either source, level, logger or message");
+        }
+
+        return event -> event.context;
+    }
+
+    @Override
+    public BiFunction<MapPath<String, String, StringPath>, Map<String, String>, BooleanExpression> getSingleValueExpressionGenerator(DSLOperator dslOperator) {
+        return SINGLE_VALUE_BOOLEAN_EXPRESSION_GENERATOR_MAP.get(dslOperator);
+    }
+
+    @Override
+    public BiFunction<MapPath<String, String, StringPath>, Map<String, String>[], BooleanExpression> getMultiValueExpressionGenerator(DSLOperator dslOperator) {
+        return MULTI_VALUE_BOOLEAN_EXPRESSION_GENERATOR_MAP.get(dslOperator);
+    }
+
+    private static BooleanExpression singleValueBaseExpression(Map<String, String> valueMap, Function<Map.Entry<String, String>, BooleanExpression> booleanExpressionFunction) {
+
+        return valueMap.entrySet()
+                .stream()
+                // this is always going to be a single item
+                .findFirst()
+                .map(booleanExpressionFunction)
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Key-value pair is missing in source value map: %s", valueMap)));
+    }
+
+    private static BooleanExpression multiValueBaseExpression(MapPath<String, String, StringPath> mapPath,
+                                                              Map<String, String>[] valueMapArray) {
+
+        return Stream.of(valueMapArray)
+                .map(valueMap -> singleValueBaseExpression(valueMap, mapContains(mapPath)))
+                .reduce(BooleanExpression::or)
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Key-value pair is missing in source value map array: %s", Arrays.toString(valueMapArray))));
+    }
+
+    private static Function<Map.Entry<String, String>, BooleanExpression> mapContains(MapPath<String, String, StringPath> mapPath) {
+        return entry -> mapPath.contains(entry.getKey(), entry.getValue());
+    }
+
+    private static Function<Map.Entry<String, String>, BooleanExpression> mapContainsLike(MapPath<String, String, StringPath> mapPath) {
+        return entry -> mapPath.get(entry.getKey()).containsIgnoreCase(entry.getValue());
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringQDSLPathMappingRegistry.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringQDSLPathMappingRegistry.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
 
 /**
  * {@link MappingRegistry} implementation for database fields accessible via {@link StringPath} QueryDSL expressions.
- * Currently used for source, level, logger and messages fields of log records. Base type is (implicitly) string.
+ * Currently used for source, level, logger, message and thread fields of log records. Base type is (implicitly) string.
  *
  * @author Peter Smith
  */
@@ -27,7 +27,8 @@ public class StringQDSLPathMappingRegistry implements MappingRegistry<StringPath
             DSLObject.SOURCE, event -> event.source,
             DSLObject.LEVEL, event -> event.level,
             DSLObject.LOGGER, event -> event.loggerName,
-            DSLObject.MESSAGE, event -> event.content
+            DSLObject.MESSAGE, event -> event.content,
+            DSLObject.THREAD, event -> event.threadName
     );
 
     private static final Map<DSLOperator, BiFunction<StringPath, String, BooleanExpression>> SINGLE_VALUE_BOOLEAN_EXPRESSION_GENERATOR_MAP = Map.of(

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/AbstractTextConditionExpressionStrategy.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/AbstractTextConditionExpressionStrategy.java
@@ -1,0 +1,30 @@
+package hu.psprog.leaflet.tlp.core.service.qdsl.expression.strategy.impl;
+
+import hu.psprog.leaflet.tlp.core.service.qdsl.expression.strategy.ExpressionStrategy;
+import hu.psprog.leaflet.tlql.ir.DSLOperator;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Common abstract {@link ExpressionStrategy} implementation for text or text-like condition expressions.
+ *
+ * @author Peter Smith
+ */
+abstract class AbstractTextConditionExpressionStrategy implements ExpressionStrategy {
+
+    /**
+     * {@link DSLOperator}s that are supposed to be used in a multi-value condition expression.
+     */
+    private static final List<DSLOperator> MULTI_VALUE_EXPRESSION_OPERATORS = Arrays.asList(DSLOperator.EITHER, DSLOperator.NONE);
+
+    /**
+     * Checks if the given {@link DSLOperator} is a multi-value expression operator.
+     *
+     * @param dslOperator {@link DSLOperator} to be checked
+     * @return {@code true} if the operator is multi-value, {@code false} otherwise
+     */
+    protected boolean isMultiValueExpression(DSLOperator dslOperator) {
+        return MULTI_VALUE_EXPRESSION_OPERATORS.contains(dslOperator);
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/StringMapConditionExpressionStrategy.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/StringMapConditionExpressionStrategy.java
@@ -1,0 +1,65 @@
+package hu.psprog.leaflet.tlp.core.service.qdsl.expression.strategy.impl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.MapPath;
+import com.querydsl.core.types.dsl.StringPath;
+import hu.psprog.leaflet.tlp.core.domain.ExpressionStrategyGroup;
+import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
+import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
+import hu.psprog.leaflet.tlql.ir.DSLCondition;
+import hu.psprog.leaflet.tlql.ir.DSLOperator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * {@link AbstractTextConditionExpressionStrategy} implementation for text-map field expressions.
+ * Supports the "context" field, with the following operators:
+ *  - equals,
+ *  - not equals,
+ *  - either,
+ *  - none,
+ *  - like.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class StringMapConditionExpressionStrategy extends AbstractTextConditionExpressionStrategy {
+
+    private final MappingRegistry<MapPath<String, String, StringPath>, Map<String, String>> mappingRegistry;
+
+    @Autowired
+    public StringMapConditionExpressionStrategy(MappingRegistry<MapPath<String, String, StringPath>, Map<String, String>> mappingRegistry) {
+        this.mappingRegistry = mappingRegistry;
+    }
+
+    @Override
+    public BooleanExpression applyStrategy(QLoggingEvent event, DSLCondition dslCondition) {
+
+        MapPath<String, String, StringPath> path = mappingRegistry.getQDSLPath(dslCondition.getObjectContext().getObject()).apply(event);
+        DSLOperator operator = dslCondition.getOperator();
+
+        return isMultiValueExpression(dslCondition.getOperator())
+                ? mappingRegistry.getMultiValueExpressionGenerator(operator).apply(path, createParameterMapArray(dslCondition))
+                : mappingRegistry.getSingleValueExpressionGenerator(operator).apply(path, createParameterMap(dslCondition, dslCondition.getValue()));
+    }
+
+    @Override
+    public ExpressionStrategyGroup forGroup() {
+        return ExpressionStrategyGroup.TEXT_MAP_CONDITION;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String>[] createParameterMapArray(DSLCondition dslCondition) {
+
+        return dslCondition.getMultipleValue()
+                .stream()
+                .map(value -> createParameterMap(dslCondition, value))
+                .toArray(Map[]::new);
+    }
+
+    private Map<String, String> createParameterMap(DSLCondition dslCondition, String value) {
+        return Map.of(dslCondition.getObjectContext().getSpecialization(), value);
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TextConditionExpressionStrategy.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TextConditionExpressionStrategy.java
@@ -5,18 +5,14 @@ import com.querydsl.core.types.dsl.StringPath;
 import hu.psprog.leaflet.tlp.core.domain.ExpressionStrategyGroup;
 import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
 import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
-import hu.psprog.leaflet.tlp.core.service.qdsl.expression.strategy.ExpressionStrategy;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
- * {@link ExpressionStrategy} implementation for textual field expressions.
+ * {@link AbstractTextConditionExpressionStrategy} implementation for textual field expressions.
  * Supports the "source", "level", "message" and "logger" fields, with the following operators:
  *  - equals,
  *  - not equals,
@@ -27,9 +23,7 @@ import java.util.List;
  * @author Peter Smith
  */
 @Component
-public class TextConditionExpressionStrategy implements ExpressionStrategy {
-
-    private static final List<DSLOperator> MULTI_VALUE_EXPRESSION_OPERATORS = Arrays.asList(DSLOperator.EITHER, DSLOperator.NONE);
+public class TextConditionExpressionStrategy extends AbstractTextConditionExpressionStrategy {
 
     private final MappingRegistry<StringPath, String> mappingRegistry;
 
@@ -41,7 +35,7 @@ public class TextConditionExpressionStrategy implements ExpressionStrategy {
     @Override
     public BooleanExpression applyStrategy(QLoggingEvent event, DSLCondition dslCondition) {
 
-        StringPath path = mappingRegistry.getQDSLPath(dslCondition.getObject()).apply(event);
+        StringPath path = mappingRegistry.getQDSLPath(dslCondition.getObjectContext().getObject()).apply(event);
         DSLOperator operator = dslCondition.getOperator();
 
         return isMultiValueExpression(operator)
@@ -52,7 +46,7 @@ public class TextConditionExpressionStrategy implements ExpressionStrategy {
     private String[] prepareMultiValueExpression(DSLCondition dslCondition) {
 
         return dslCondition.getMultipleValue().stream()
-                .map(value -> dslCondition.getObject() == DSLObject.LEVEL
+                .map(value -> dslCondition.getObjectContext().getObject() == DSLObject.LEVEL
                         ? value.toUpperCase()
                         : value)
                 .toArray(String[]::new);
@@ -61,9 +55,5 @@ public class TextConditionExpressionStrategy implements ExpressionStrategy {
     @Override
     public ExpressionStrategyGroup forGroup() {
         return ExpressionStrategyGroup.TEXT_CONDITION;
-    }
-
-    private boolean isMultiValueExpression(DSLOperator dslOperator) {
-        return MULTI_VALUE_EXPRESSION_OPERATORS.contains(dslOperator);
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TimestampConditionExpressionStrategy.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TimestampConditionExpressionStrategy.java
@@ -51,7 +51,7 @@ public class TimestampConditionExpressionStrategy implements ExpressionStrategy 
 
         DSLTimestampValue timestampValue = dslCondition.getTimestampValue();
         DSLOperator operator = dslCondition.getOperator();
-        DateTimePath<Date> path = mappingRegistry.getQDSLPath(dslCondition.getObject()).apply(event);
+        DateTimePath<Date> path = mappingRegistry.getQDSLPath(dslCondition.getObjectContext().getObject()).apply(event);
 
         return operator == DSLOperator.BETWEEN
                 ? createIntervalExpression(path, timestampValue)

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LogRequestToDSLQueryModelConverterTest.java
@@ -7,6 +7,7 @@ import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLConditionGroup;
 import hu.psprog.leaflet.tlql.ir.DSLLogicalOperator;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import hu.psprog.leaflet.tlql.ir.DSLOrderDirection;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
@@ -91,7 +92,7 @@ class LogRequestToDSLQueryModelConverterTest {
         setDefaultPagination(expectedDslQueryModel);
 
         DSLCondition messageCondition = new DSLCondition();
-        messageCondition.setObject(DSLObject.MESSAGE);
+        messageCondition.setObjectContext(new DSLObjectContext(DSLObject.MESSAGE, null));
         messageCondition.setOperator(DSLOperator.LIKE);
         messageCondition.setValue(logRequest.getContent());
         expectedDslQueryModel.getConditionGroups().get(0).getConditions().add(messageCondition);
@@ -118,25 +119,25 @@ class LogRequestToDSLQueryModelConverterTest {
         setDefaultPagination(expectedDslQueryModel);
 
         DSLCondition messageCondition = new DSLCondition();
-        messageCondition.setObject(DSLObject.MESSAGE);
+        messageCondition.setObjectContext(new DSLObjectContext(DSLObject.MESSAGE, null));
         messageCondition.setOperator(DSLOperator.LIKE);
         messageCondition.setValue(logRequest.getContent());
         messageCondition.setNextConditionOperator(DSLLogicalOperator.AND);
 
         DSLCondition sourceCondition = new DSLCondition();
-        sourceCondition.setObject(DSLObject.SOURCE);
+        sourceCondition.setObjectContext(new DSLObjectContext(DSLObject.SOURCE, null));
         sourceCondition.setOperator(DSLOperator.EQUALS);
         sourceCondition.setValue(logRequest.getSource());
         sourceCondition.setNextConditionOperator(DSLLogicalOperator.AND);
 
         DSLCondition levelCondition = new DSLCondition();
-        levelCondition.setObject(DSLObject.LEVEL);
+        levelCondition.setObjectContext(new DSLObjectContext(DSLObject.LEVEL, null));
         levelCondition.setOperator(DSLOperator.EQUALS);
         levelCondition.setValue(logRequest.getLevel());
         levelCondition.setNextConditionOperator(DSLLogicalOperator.AND);
 
         DSLCondition fromCondition = new DSLCondition();
-        fromCondition.setObject(DSLObject.TIMESTAMP);
+        fromCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         fromCondition.setOperator(DSLOperator.GREATER_THAN);
         fromCondition.setTimestampValue(new DSLTimestampValue(prepareLocalDateTime("2021-04-10")));
 
@@ -162,7 +163,7 @@ class LogRequestToDSLQueryModelConverterTest {
         setDefaultPagination(expectedDslQueryModel);
 
         DSLCondition toCondition = new DSLCondition();
-        toCondition.setObject(DSLObject.TIMESTAMP);
+        toCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         toCondition.setOperator(DSLOperator.LESS_THAN);
         toCondition.setTimestampValue(new DSLTimestampValue(prepareLocalDateTime("2021-04-15")));
 
@@ -188,7 +189,7 @@ class LogRequestToDSLQueryModelConverterTest {
         setDefaultPagination(expectedDslQueryModel);
 
         DSLCondition toCondition = new DSLCondition();
-        toCondition.setObject(DSLObject.TIMESTAMP);
+        toCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         toCondition.setOperator(DSLOperator.BETWEEN);
         toCondition.setTimestampValue(new DSLTimestampValue(DSLTimestampValue.IntervalType.FULL_EXCLUSIVE,
                 prepareLocalDateTime("2021-04-10"), prepareLocalDateTime("2021-04-15")));

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LoggingEventEntityToDomainConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/conversion/LoggingEventEntityToDomainConverterTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -36,7 +37,7 @@ public class LoggingEventEntityToDomainConverterTest {
     private LoggingEventEntityToDomainConverter converter;
 
     @Test
-    public void shouldConvertWithoutException() {
+    public void shouldConvertWithoutExceptionAndContext() {
 
         // given
         LoggingEvent loggingEvent = LoggingEvent.getBuilder()
@@ -59,17 +60,20 @@ public class LoggingEventEntityToDomainConverterTest {
         assertThat(result.level(), equalTo(LOG_LEVEL.getLevelStr()));
         assertThat(result.loggerName(), equalTo(LOGGER_NAME));
         assertThat(result.threadName(), equalTo(THREAD_NAME));
+        assertThat(result.context(), equalTo(Collections.emptyMap()));
         assertThat(result.exception(), nullValue());
     }
 
     @Test
-    public void shouldConvertWithException() {
+    public void shouldConvertWithExceptionAndContext() {
 
         // given
         ThrowableProxyLogItem cause1 = prepareThrowableProxyLogItem(2, null, false);
         ThrowableProxyLogItem cause2 = prepareThrowableProxyLogItem(3, cause1, true);
+        Map<String, String> context = Map.of("requestID", "request-1234");
         LoggingEvent loggingEvent = LoggingEvent.getBuilder()
                 .withException(prepareThrowableProxyLogItem(1, cause2, false))
+                .withContext(context)
                 .build();
 
         // when
@@ -92,6 +96,7 @@ public class LoggingEventEntityToDomainConverterTest {
         assertThat(result.exception().cause().cause().stackTrace(), equalTo("stack-trace 2"));
         assertThat(result.exception().cause().cause().cause(), nullValue());
         assertThat(result.exception().cause().cause().suppressed().isEmpty(), is(true));
+        assertThat(result.context(), equalTo(context));
     }
 
     private ThrowableProxyLogItem prepareThrowableProxyLogItem(int exceptionID, ThrowableProxyLogItem cause, boolean withSuppressed) {

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/builder/ExpressionBuilderTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/builder/ExpressionBuilderTest.java
@@ -10,6 +10,7 @@ import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLConditionGroup;
 import hu.psprog.leaflet.tlql.ir.DSLLogicalOperator;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,7 +184,7 @@ public class ExpressionBuilderTest {
     private void addCondition(DSLQueryModel dslQueryModel, int groupIndex, DSLObject object, DSLLogicalOperator nextOperator) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(object);
+        dslCondition.setObjectContext(new DSLObjectContext(object, null));
         dslCondition.setNextConditionOperator(nextOperator);
 
         dslQueryModel.getConditionGroups().get(groupIndex).getConditions().add(dslCondition);

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringMapQDSLPathMappingRegistryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringMapQDSLPathMappingRegistryTest.java
@@ -1,0 +1,112 @@
+package hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.impl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.MapPath;
+import com.querydsl.core.types.dsl.StringPath;
+import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
+import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link StringMapQDSLPathMappingRegistry}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class StringMapQDSLPathMappingRegistryTest {
+
+    @InjectMocks
+    private StringMapQDSLPathMappingRegistry stringMapQDSLPathMappingRegistry;
+
+    @Test
+    public void shouldGetQDSLPathReturnContextPath() {
+
+        // given
+        QLoggingEvent loggingEvent = new QLoggingEvent("loggingEvent");
+        DSLObject dslObject = DSLObject.CONTEXT;
+
+        // when
+        Function<QLoggingEvent, MapPath<String, String, StringPath>> result = stringMapQDSLPathMappingRegistry.getQDSLPath(dslObject);
+
+        // then
+        assertThat(result.apply(loggingEvent).toString(), equalTo("loggingEvent.context"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DSLObject.class, mode = EnumSource.Mode.EXCLUDE, names = "CONTEXT")
+    public void shouldGetQDSLPathThrowErrorIfObjectIsNotContext(DSLObject dslObject) {
+
+        // when
+        assertThrows(IllegalArgumentException.class, () -> stringMapQDSLPathMappingRegistry.getQDSLPath(dslObject));
+
+        // then
+        // exception expected
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleValueExpressionGeneratorArgumentsProvider")
+    public void shouldGetSingleValueExpressionGeneratorReturnTheCorrespondingMapperFunction(DSLOperator dslOperator, String expectedExpression) {
+
+        // given
+        QLoggingEvent event = new QLoggingEvent("loggingEvent");
+        Map<String, String> valueMap = Map.of("requestID", "abcd1234");
+
+        // when
+        BiFunction<MapPath<String, String, StringPath>, Map<String, String>, BooleanExpression> result =
+                stringMapQDSLPathMappingRegistry.getSingleValueExpressionGenerator(dslOperator);
+
+        // then
+        assertThat(result.apply(event.context, valueMap).toString(), equalTo(expectedExpression));
+    }
+
+    @ParameterizedTest
+    @MethodSource("multiValueExpressionGeneratorArgumentsProvider")
+    public void shouldGetMultiValueExpressionGeneratorReturnTheCorrespondingMapperFunction(DSLOperator dslOperator, String expectedExpression) {
+
+        // given
+        QLoggingEvent event = new QLoggingEvent("loggingEvent");
+        Map<String, String>[] valueMap = List.of(Map.of("trace_id", "abcd1234"), Map.of("trace_id", "efgh9876")).toArray(Map[]::new);
+
+        // when
+        BiFunction<MapPath<String, String, StringPath>, Map<String, String>[], BooleanExpression> result =
+                stringMapQDSLPathMappingRegistry.getMultiValueExpressionGenerator(dslOperator);
+
+        // then
+        assertThat(result.apply(event.context, valueMap).toString(), equalTo(expectedExpression));
+    }
+
+    private static Stream<Arguments> singleValueExpressionGeneratorArgumentsProvider() {
+
+        return Stream.of(
+                Arguments.of(DSLOperator.EQUALS, "loggingEvent.context.get(requestID) = abcd1234"),
+                Arguments.of(DSLOperator.NOT_EQUALS, "!(loggingEvent.context.get(requestID) = abcd1234)"),
+                Arguments.of(DSLOperator.LIKE, "containsIc(loggingEvent.context.get(requestID),abcd1234)")
+        );
+    }
+
+    private static Stream<Arguments> multiValueExpressionGeneratorArgumentsProvider() {
+
+        return Stream.of(
+                Arguments.of(DSLOperator.EITHER, "loggingEvent.context.get(trace_id) = abcd1234 || loggingEvent.context.get(trace_id) = efgh9876"),
+                Arguments.of(DSLOperator.NONE, "!(loggingEvent.context.get(trace_id) = abcd1234 || loggingEvent.context.get(trace_id) = efgh9876)")
+        );
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringQDSLPathMappingRegistryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/mapping/impl/StringQDSLPathMappingRegistryTest.java
@@ -90,7 +90,8 @@ class StringQDSLPathMappingRegistryTest {
                 Arguments.of(DSLObject.SOURCE, "source"),
                 Arguments.of(DSLObject.LEVEL, "level"),
                 Arguments.of(DSLObject.LOGGER, "loggerName"),
-                Arguments.of(DSLObject.MESSAGE, "content")
+                Arguments.of(DSLObject.MESSAGE, "content"),
+                Arguments.of(DSLObject.THREAD, "threadName")
         );
     }
 

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/StringMapConditionExpressionStrategyTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/StringMapConditionExpressionStrategyTest.java
@@ -1,0 +1,110 @@
+package hu.psprog.leaflet.tlp.core.service.qdsl.expression.strategy.impl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.MapPath;
+import com.querydsl.core.types.dsl.StringPath;
+import hu.psprog.leaflet.tlp.core.domain.ExpressionStrategyGroup;
+import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
+import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
+import hu.psprog.leaflet.tlql.ir.DSLCondition;
+import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
+import hu.psprog.leaflet.tlql.ir.DSLOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link StringMapConditionExpressionStrategy}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class StringMapConditionExpressionStrategyTest {
+
+    @Mock
+    private MappingRegistry<MapPath<String, String, StringPath>, Map<String, String>> mappingRegistry;
+
+    @Mock
+    private BiFunction<MapPath<String, String, StringPath>, Map<String, String>, BooleanExpression> singleValueExpression;
+
+    @Mock
+    private BiFunction<MapPath<String, String, StringPath>, Map<String, String>[], BooleanExpression> multiValueExpression;
+
+    @InjectMocks
+    private StringMapConditionExpressionStrategy stringMapConditionExpressionStrategy;
+
+    @Test
+    public void shouldApplyStrategyGenerateSingleValueContextConditionExpression() {
+
+        // given
+        QLoggingEvent event = new QLoggingEvent("loggingEvent");
+        DSLCondition dslCondition = prepareDSLCondition(DSLOperator.EQUALS, "requestID", "abcd1234");
+        Function<QLoggingEvent, MapPath<String, String, StringPath>> stringMapPathFunction = loggingEvent -> loggingEvent.context;
+
+        given(mappingRegistry.getQDSLPath(DSLObject.CONTEXT)).willReturn(stringMapPathFunction);
+        given(mappingRegistry.getSingleValueExpressionGenerator(DSLOperator.EQUALS)).willReturn(singleValueExpression);
+
+        // when
+        stringMapConditionExpressionStrategy.applyStrategy(event, dslCondition);
+
+        // then
+        verify(singleValueExpression).apply(event.context, Map.of("requestID", "abcd1234"));
+    }
+
+    @Test
+    public void shouldApplyStrategyGenerateMultiValueContextConditionExpression() {
+
+        // given
+        QLoggingEvent event = new QLoggingEvent("loggingEvent");
+        DSLCondition dslCondition = prepareDSLCondition(DSLOperator.EITHER, "trace_id", "abcd1234", "efgh9876");
+        Function<QLoggingEvent, MapPath<String, String, StringPath>> stringMapPathFunction = loggingEvent -> loggingEvent.context;
+
+        given(mappingRegistry.getQDSLPath(DSLObject.CONTEXT)).willReturn(stringMapPathFunction);
+        given(mappingRegistry.getMultiValueExpressionGenerator(DSLOperator.EITHER)).willReturn(multiValueExpression);
+
+        // when
+        stringMapConditionExpressionStrategy.applyStrategy(event, dslCondition);
+
+        // then
+        verify(multiValueExpression).apply(event.context, List.of(Map.of("trace_id", "abcd1234"), Map.of("trace_id", "efgh9876")).toArray(Map[]::new));
+    }
+
+    @Test
+    public void shouldForGroupReturnTextMapConditionExpressionStrategyGroup() {
+
+        // when
+        ExpressionStrategyGroup result = stringMapConditionExpressionStrategy.forGroup();
+
+        // then
+        assertThat(result, equalTo(ExpressionStrategyGroup.TEXT_MAP_CONDITION));
+    }
+
+    private DSLCondition prepareDSLCondition(DSLOperator dslOperator, String specialization, String... values) {
+
+        DSLCondition dslCondition = new DSLCondition();
+        dslCondition.setObjectContext(new DSLObjectContext(DSLObject.CONTEXT, specialization));
+        dslCondition.setOperator(dslOperator);
+
+        if (values.length > 1) {
+            dslCondition.setMultipleValue(Arrays.asList(values));
+        } else {
+            dslCondition.setValue(values[0]);
+        }
+
+        return dslCondition;
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TextConditionExpressionStrategyTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TextConditionExpressionStrategyTest.java
@@ -8,6 +8,7 @@ import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
 import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,7 +108,7 @@ class TextConditionExpressionStrategyTest {
     private DSLCondition prepareDSLCondition(DSLObject dslObject, DSLOperator dslOperator, String... values) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(dslObject);
+        dslCondition.setObjectContext(new DSLObjectContext(dslObject, null));
         dslCondition.setOperator(dslOperator);
 
         if (values.length > 1) {

--- a/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TimestampConditionExpressionStrategyTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/tlp/core/service/qdsl/expression/strategy/impl/TimestampConditionExpressionStrategyTest.java
@@ -7,6 +7,7 @@ import hu.psprog.leaflet.tlp.core.domain.QLoggingEvent;
 import hu.psprog.leaflet.tlp.core.service.qdsl.expression.mapping.MappingRegistry;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import hu.psprog.leaflet.tlql.ir.DSLTimestampValue;
 import org.junit.jupiter.api.Test;
@@ -165,7 +166,7 @@ class TimestampConditionExpressionStrategyTest {
     private DSLCondition prepareDSLCondition(String leftDate, String rightDate, DSLOperator dslOperator, DSLTimestampValue.IntervalType intervalType) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(DSLObject.TIMESTAMP);
+        dslCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         dslCondition.setOperator(dslOperator);
         dslCondition.setTimestampValue(intervalType == DSLTimestampValue.IntervalType.NONE
                 ? new DSLTimestampValue(prepareLocalDateTime(leftDate))

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tlp</artifactId>
-    <version>2.4.0-dev</version>
+    <version>2.5.0-dev</version>
     <modules>
         <module>web</module>
         <module>core</module>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>3.0-r2305.1</version>
+        <version>3.2-r2307.3</version>
     </parent>
 
     <properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.4.0-dev</version>
+        <version>2.5.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web/src/main/java/hu/psprog/leaflet/tlp/web/rest/controller/LogsController.java
+++ b/web/src/main/java/hu/psprog/leaflet/tlp/web/rest/controller/LogsController.java
@@ -59,8 +59,10 @@ public class LogsController {
      * @param logRequest paging and filtering parameters parsed as {@link LogRequest} object
      * @return paged list of log events returned for given {@link LogRequest} with HTTP status 200
      * @throws LogRetrievalFailureException when {@link LogRequest} cannot be processed
+     * @deprecated this endpoint is part of the old TLP API and will be removed in the next major version
      */
     @GetMapping(path = PATH_LOGS)
+    @Deprecated(forRemoval = true)
     public ResponseEntity<LogEventPage> getLogs(LogRequest logRequest) throws LogRetrievalFailureException {
 
         try {


### PR DESCRIPTION
LFLT-569 Add support for querying MDC data in TLP
 - Updated logging event converter to include context value map
 - Implemented QueryDSL path mapping for context
 - Implemented generating QueryDSL boolean expression for context values
 - Aligned code for TLQL v1.2.0
 - Marked old GET /logs endpoint as deprecated
 - Updated base BOM version to 3.2-r2307.3
 - Bumped application version to 2.5.0-dev

LFLT-572 Add support for querying log thread in TLP
 - Implemented generating QueryDSL boolean expression for thread value
 - Aligned tests