### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  gh: circleci/github-cli@2.7.0
+  gh: circleci/github-cli@2.7.2
 
 # Common parameters for CircleCI build config
 parameters:
@@ -24,6 +24,9 @@ parameters:
   version_file:
     type: string
     default: "version"
+  deploy_name:
+    type: string
+    default: "prod-deploy-tlp"
 
 # Reusable commands
 commands:
@@ -93,6 +96,15 @@ jobs:
             fi
           name: Push Docker image
       - run:
+          name: Plan deployment
+          command: |
+            if [[ $CIRCLE_BRANCH == "deploy" ]]; then
+              circleci run release plan << pipeline.parameters.deploy_name >> \
+                --environment-name=production \
+                --component-name=<< pipeline.parameters.app_name >> \
+                --target-version="${PROJECT_VERSION}"
+            fi
+      - run:
           command: |
             mkdir -p << pipeline.parameters.workspace_dir >>
             cp ./<< pipeline.parameters.executable_source_dir >><< pipeline.parameters.executable_file >> << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
@@ -127,12 +139,17 @@ jobs:
           command: |
             set -e
             
+            circleci run release update << pipeline.parameters.deploy_name >> --status=running
+            
             echo "Requesting access token ..."
             token="$(domino-cli --cicd auth --generate-token)" || exit 1
             export DOMINO_CLI_PREAUTHORIZED_TOKEN=$token
             
             domino-cli --cicd import
             echo "Deployment definition successfully imported"
+            
+            domino-cli --cicd oauth-import << pipeline.parameters.app_name >>
+            echo "Deployment OAuth descriptor successfully imported"
             
             domino-cli --cicd deploy << pipeline.parameters.app_name >> ${PROJECT_VERSION}
             echo "Successfully deployed application << pipeline.parameters.app_name >> v${PROJECT_VERSION}"
@@ -141,6 +158,24 @@ jobs:
             echo "Successfully started application << pipeline.parameters.app_name >>"
 
           name: Deploy via Domino
+      - run:
+          name: Update planned release to SUCCESS
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update planned release to FAILED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=FAILED
+          when: on_fail
+
+  cancel-deploy:
+    executor: base
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=CANCELED
 
   # Leaflet Tiny Log Processor - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
@@ -216,6 +251,11 @@ workflows:
                 job_type: deployment
                 pipeline_id: << pipeline.id >>
                 pipeline_number: << pipeline.number >>
+
+      - cancel-deploy:
+          requires:
+            - deploy:
+                - canceled
 
       - publish-github-release:
           context:

--- a/.domino/deployment.yml
+++ b/.domino/deployment.yml
@@ -19,6 +19,8 @@ domino:
             APP_ARGS: |
               --spring.profiles.active=production
               --spring.config.location=/opt/tlp/appconfig_tlp.yml
+              --spring.mongodb.username=[dsm:apps.tlp.mongo.username]
+              --spring.mongodb.password=[dsm:apps.tlp.mongo.password]
           volumes:
             "[dsm:volume.logs]": "/opt/tlp/logs:rw"
             "[dsm:volume.config.tlp]": "/opt/tlp/appconfig_tlp.yml:ro"

--- a/.domino/oauth.yml
+++ b/.domino/oauth.yml
@@ -1,0 +1,20 @@
+domino:
+  oauth:
+    tlp:
+      behavior:
+        target-provider: gateway-psproghu
+        roll-client-secret-on-deploy: true
+        use-secret-manager-for:
+          - client-secret
+          - client-id
+      tenant:
+        environment: prod
+        name: psproghu
+      resource-server:
+        use-audience: true
+        registered-permissions:
+          - read:logs
+        allowed-clients:
+          - name: lpmc
+            allowed-permissions:
+              - read:logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ ARG APP_USER=leaflet
 ARG APP_HOME=/opt/tlp
 ARG APP_EXECUTABLE=leaflet-tlp-exec.jar
 ENV ENV_APP_EXECUTABLE=$APP_EXECUTABLE
+ENV JAVA_OPTS="-Xmx128M"
 
 RUN addgroup --system --gid 1000 $APP_USER
 RUN adduser --system --no-create-home --gid 1000 --uid 1000 $APP_USER
 RUN mkdir -p $APP_HOME
 ADD web/target/$APP_EXECUTABLE $APP_HOME
-ADD config/leaflet-tlp-exec.conf $APP_HOME
 
 WORKDIR $APP_HOME
 RUN chmod 744 $APP_HOME
@@ -18,4 +18,4 @@ RUN chown -R $APP_USER:$APP_USER $APP_HOME
 
 USER $APP_USER
 
-ENTRYPOINT ./$ENV_APP_EXECUTABLE ${APP_ARGS}
+ENTRYPOINT exec java $JAVA_OPTS -jar $ENV_APP_EXECUTABLE ${APP_ARGS}

--- a/config/leaflet-tlp-exec.conf
+++ b/config/leaflet-tlp-exec.conf
@@ -1,1 +1,0 @@
-JAVA_OPTS=-Xmx128M

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.6.1-dev</version>
+        <version>2.7.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -25,8 +25,8 @@
             <artifactId>leaflet-tlql-processor</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LogLevel.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LogLevel.java
@@ -1,7 +1,7 @@
 package hu.psprog.leaflet.tlp.core.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Log level node deserialization model that conforms Logback-original log event model format.

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LoggingEvent.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/LoggingEvent.java
@@ -1,10 +1,10 @@
 package hu.psprog.leaflet.tlp.core.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Date;
 import java.util.Map;

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/StackTraceElementProxyLogItem.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/StackTraceElementProxyLogItem.java
@@ -1,7 +1,7 @@
 package hu.psprog.leaflet.tlp.core.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Stacktrace element node deserialization model that conforms Logback-original log event model format.

--- a/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/ThrowableProxyLogItem.java
+++ b/core/src/main/java/hu/psprog/leaflet/tlp/core/domain/ThrowableProxyLogItem.java
@@ -1,7 +1,7 @@
 package hu.psprog.leaflet.tlp.core.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tlp</artifactId>
-    <version>2.6.1-dev</version>
+    <version>2.7.0-dev</version>
     <modules>
         <module>web</module>
         <module>core</module>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <properties>
@@ -79,11 +79,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <proc>full</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/lombok.config
+++ b/web/lombok.config
@@ -1,0 +1,1 @@
+lombok.jacksonized.jacksonVersion += 3

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tlp</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.6.1-dev</version>
+        <version>2.7.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,12 +26,8 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-resource-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,7 +47,6 @@
                         <argument>--spring.profiles.active=${spring.profiles.active}</argument>
                         <argument>--spring.config.location=${spring.config.location}</argument>
                     </arguments>
-                    <executable>true</executable>
                 </configuration>
                 <executions>
                     <execution>

--- a/web/src/main/java/hu/psprog/leaflet/tlp/web/config/listener/ApplicationStartupFinishedListener.java
+++ b/web/src/main/java/hu/psprog/leaflet/tlp/web/config/listener/ApplicationStartupFinishedListener.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.tlp.web.config.listener;
 
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ public class ApplicationStartupFinishedListener implements ApplicationListener<C
     }
 
     @Override
-    public void onApplicationEvent(ContextRefreshedEvent event) {
+    public void onApplicationEvent(@NonNull ContextRefreshedEvent event) {
         optionalBuildProperties.ifPresent(buildProperties ->
                 LOGGER.info("Application loaded successfully, running version v{}, built on {}", buildProperties.getVersion(), getBuildTime(buildProperties)));
     }


### PR DESCRIPTION
 - Aligned Jackson imports and configuration
 - Switched to stack base BOM v6.0-r2604.2
 - Bumped application version to 2.7.0-dev
 - POM fixes (annotation processing and Mockito warnings)
 - Added OAuth application descriptor and import step in pipeline
 - Added deploy markers to CircleCI config